### PR TITLE
Maze pso and aco

### DIFF
--- a/lab08/pyproject.toml
+++ b/lab08/pyproject.toml
@@ -51,7 +51,7 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.pyright]
-include = ["task01/src", "task01/tests"]
+include = ["task01/src", "task01/tests", "task02/src", "task02/tests", "task03/src"]
 exclude = [".venv", "__pycache__", "**/node_modules", "**/.*"]
 typeCheckingMode = "standard"
 venvPath = "./"

--- a/lab08/pyproject.toml
+++ b/lab08/pyproject.toml
@@ -51,7 +51,7 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.pyright]
-include = ["task01/src", "task01/tests", "task02/src", "task02/tests", "task03/src"]
+include = ["task01/src", "task01/tests", "task02/src", "task02/tests", "task03/src", "task03/tests"]
 exclude = [".venv", "__pycache__", "**/node_modules", "**/.*"]
 typeCheckingMode = "standard"
 venvPath = "./"

--- a/lab08/task03/configs/default_config.yaml
+++ b/lab08/task03/configs/default_config.yaml
@@ -1,0 +1,36 @@
+experiment_name: default
+output_root: task03/experiments
+
+aco:
+  ant_count: 300
+  alpha: 0.5 # Pheromone importance
+  beta: 1.2 # Distance/heuristic importance
+  pheromone_evaporation_rate: 0.40
+  pheromone_constant: 1000.0
+  iterations: 250
+
+pso:
+  particle_count: 200
+  iterations: 300
+  sequence_length: 30
+  lower_bound: -4.0
+  upper_bound: 4.0
+  velocity_clamp: 2.0
+  c1: 0.8
+  c2: 0.3
+  w: 0.8
+  step_weight: 1.0
+  revisit_weight: 3.0
+  goal_distance_weight: 5.0
+  failure_penalty: 2000.0
+
+plotting:
+  enabled: true
+  save_cost_plot: true
+  figure_dpi: 120
+
+gif:
+  enabled: true
+  aco_evolution: true
+  pso_evolution: true
+  frame_duration_ms: 100

--- a/lab08/task03/data/maze.py
+++ b/lab08/task03/data/maze.py
@@ -5,17 +5,12 @@ Maze Definition for Task 03
 12x12 maze with borders (10x10 internal grid)
 0 = passable
 1 = wall
-
-Format:
-- First row/column: border
-- Last row/column: border
-- Interior: 10x10 grid with walls
 """
 
 # 12x12 maze (including borders)
 # Start: (1, 1) - top-left corner of internal grid
 # Goal: (10, 10) - bottom-right corner of internal grid
-# Maximum steps allowed: 30 (actual solution ~20)
+# Maximum steps allowed: 30 (actual solution 20)
 
 maze = [
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],

--- a/lab08/task03/src/config.py
+++ b/lab08/task03/src/config.py
@@ -1,0 +1,158 @@
+"""Task 03 configuration models and YAML loading helpers for the maze solvers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+TASK03_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = TASK03_ROOT.parent
+DEFAULT_OUTPUT_ROOT = TASK03_ROOT / "experiments"
+DEFAULT_CONFIG_PATH = TASK03_ROOT / "configs" / "default_config.yaml"
+
+
+class ACOConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    ant_count: int = Field(default=300, gt=0)
+    alpha: float = Field(default=0.5, ge=0.0)
+    beta: float = Field(default=1.2, ge=0.0)
+    pheromone_evaporation_rate: float = Field(default=0.4, ge=0.0, le=1.0)
+    pheromone_constant: float = Field(default=1000.0, gt=0.0)
+    iterations: int = Field(default=300, gt=0)
+
+
+class PSOConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    particle_count: int = Field(default=30, gt=0)
+    iterations: int = Field(default=120, gt=0)
+    sequence_length: int = Field(default=30, gt=0)
+    lower_bound: float = Field(default=-4.0)
+    upper_bound: float = Field(default=4.0)
+    velocity_clamp: float = Field(default=2.0, gt=0.0)
+    c1: float = Field(default=0.5, ge=0.0)
+    c2: float = Field(default=0.3, ge=0.0)
+    w: float = Field(default=0.5, ge=0.0, le=1.0)
+    step_weight: float = Field(default=1.0, gt=0.0)
+    revisit_weight: float = Field(default=0.5, ge=0.0)
+    goal_distance_weight: float = Field(default=4.0, gt=0.0)
+    failure_penalty: float = Field(default=100.0, ge=0.0)
+
+
+class PlotConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    enabled: bool = True
+    save_cost_plot: bool = True
+    figure_dpi: int = Field(default=120, gt=0)
+
+
+class GifConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    enabled: bool = True
+    aco_evolution: bool = True
+    pso_evolution: bool = True
+    astar_solving: bool = True
+    sample_every_n_generations: int = Field(default=4, gt=0)
+    astar_sample_every_n_steps: int = Field(default=1, gt=0)
+    frame_duration_ms: int = Field(default=300, gt=0)
+
+
+class ExperimentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    experiment_name: str | None = None
+    output_root: Path = Path("task03/experiments")
+    aco: ACOConfig = Field(default_factory=ACOConfig)
+    pso: PSOConfig = Field(default_factory=PSOConfig)
+    plotting: PlotConfig = Field(default_factory=PlotConfig)
+    gif: GifConfig = Field(default_factory=GifConfig)
+
+    @field_validator("output_root", mode="before")
+    @classmethod
+    def _convert_output_root(cls, value: str | Path) -> Path:
+        return Path(value)
+
+
+@dataclass(frozen=True)
+class LoadedExperimentConfig:
+    config_path: Path
+    config_name: str
+    project_root: Path
+    task_root: Path
+    output_root: Path
+    output_dir: Path
+    experiment: ExperimentConfig
+
+
+def _resolve_path(raw_path: Path, base_dir: Path) -> Path:
+    return raw_path if raw_path.is_absolute() else (base_dir / raw_path)
+
+
+def _nest_legacy_sections(payload: dict[str, Any]) -> dict[str, Any]:
+    nested = dict(payload)
+    section_fields = {
+        "aco": set(ACOConfig.model_fields),
+        "pso": set(PSOConfig.model_fields),
+        "plotting": set(PlotConfig.model_fields),
+        "gif": set(GifConfig.model_fields),
+        # runs intentionally omitted — single-run mode
+    }
+    for section_name, field_names in section_fields.items():
+        if section_name in nested:
+            continue
+        section_payload = {
+            field: nested.pop(field) for field in list(field_names) if field in nested
+        }
+        if section_payload:
+            nested[section_name] = section_payload
+    return nested
+
+
+def load_experiment_config(config_path: str | Path = DEFAULT_CONFIG_PATH) -> LoadedExperimentConfig:
+    """Load and validate a task 03 maze experiment configuration."""
+
+    raw_path = Path(config_path)
+    resolved_config_path = raw_path if raw_path.is_absolute() else (PROJECT_ROOT / raw_path)
+    resolved_config_path = resolved_config_path.resolve()
+
+    if not resolved_config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {resolved_config_path}")
+
+    with resolved_config_path.open(encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+
+    if not isinstance(payload, dict):
+        raise TypeError("Configuration file must contain a YAML mapping at the top level")
+
+    experiment = ExperimentConfig(**_nest_legacy_sections(payload))
+
+    # Use the resolved output root directly (single-run mode)
+    resolved_output_root = _resolve_path(experiment.output_root, PROJECT_ROOT).resolve()
+    expected_output_root = DEFAULT_OUTPUT_ROOT.resolve()
+    if resolved_output_root != expected_output_root:
+        raise ValueError(
+            f"output_root must resolve to '{expected_output_root}', got '{resolved_output_root}'"
+        )
+
+    output_dir = resolved_output_root
+
+    # Preserve a stable config name for metadata, but do not create a per-config subfolder
+    explicit_name = (experiment.experiment_name or "").strip()
+    config_name = explicit_name if explicit_name else resolved_config_path.stem
+
+    return LoadedExperimentConfig(
+        config_path=resolved_config_path,
+        config_name=config_name,
+        project_root=PROJECT_ROOT,
+        task_root=TASK03_ROOT,
+        output_root=resolved_output_root,
+        output_dir=output_dir,
+        experiment=experiment,
+    )

--- a/lab08/task03/src/maze_aco.py
+++ b/lab08/task03/src/maze_aco.py
@@ -1,0 +1,323 @@
+"""Task 03 maze solving with Ant Colony Optimization."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.animation import FuncAnimation, PillowWriter
+from matplotlib.colors import ListedColormap
+
+from task03.data.maze import GOAL, MAX_STEPS, START, is_passable, maze
+
+from .config import DEFAULT_CONFIG_PATH, LoadedExperimentConfig, load_experiment_config
+
+DEFAULT_SEED = 42
+
+ACTIONS: tuple[tuple[int, int], ...] = ((0, -1), (1, 0), (0, 1), (-1, 0))
+ACTION_NAMES: tuple[str, ...] = ("up", "right", "down", "left")
+WALL_COLOR = "#101010"
+PATH_COLOR = "#4400ff"
+BEST_COLOR = "#eeff00"
+START_COLOR = "#00ff37"
+GOAL_COLOR = "#ee0808"
+
+
+@dataclass(frozen=True)
+class MazePathResult:
+    path: list[tuple[int, int]]
+    cost: float
+    reached_goal: bool
+    steps_taken: int
+    revisits: int
+    goal_distance: int
+
+
+def manhattan_distance(a: tuple[int, int], b: tuple[int, int]) -> int:
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def legal_neighbors(cell: tuple[int, int]) -> list[tuple[int, int]]:
+    x, y = cell
+    neighbors: list[tuple[int, int]] = []
+    for dx, dy in ACTIONS:
+        candidate = (x + dx, y + dy)
+        if is_passable(*candidate):
+            neighbors.append(candidate)
+    return neighbors
+
+
+def _softmax_choice(rng: np.random.Generator, weights: np.ndarray) -> int:
+    if weights.size == 0:
+        raise ValueError("weights must not be empty")
+    if not np.all(np.isfinite(weights)):
+        weights = np.ones_like(weights, dtype=float)
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        probabilities = np.full(weights.shape, 1.0 / weights.size, dtype=float)
+    else:
+        probabilities = weights / total
+    return int(rng.choice(weights.size, p=probabilities))
+
+
+def _evaluate_path(path: list[tuple[int, int]]) -> MazePathResult:
+    steps_taken = max(0, len(path) - 1)
+    revisits = len(path) - len(set(path))
+    goal_distance = manhattan_distance(path[-1], GOAL)
+    reached_goal = path[-1] == GOAL
+    if reached_goal:
+        cost = float(steps_taken) + revisits * 0.25
+    else:
+        cost = 100.0 + float(steps_taken) + goal_distance * 4.0 + revisits * 0.5
+    return MazePathResult(
+        path=path,
+        cost=cost,
+        reached_goal=reached_goal,
+        steps_taken=steps_taken,
+        revisits=revisits,
+        goal_distance=goal_distance,
+    )
+
+
+def _construct_ant_path(
+    rng: np.random.Generator,
+    pheromone: dict[tuple[tuple[int, int], tuple[int, int]], float],
+    *,
+    alpha: float,
+    beta: float,
+    max_steps: int,
+) -> MazePathResult:
+    current = START
+    path = [current]
+    visited_counts: dict[tuple[int, int], int] = defaultdict(int)
+    visited_counts[current] = 1
+
+    for _step in range(max_steps):
+        if current == GOAL:
+            break
+        neighbors = legal_neighbors(current)
+        if not neighbors:
+            break
+
+        weights = []
+        for neighbor in neighbors:
+            pheromone_level = pheromone.get((current, neighbor), 1.0)
+            heuristic = 1.0 / (1.0 + manhattan_distance(neighbor, GOAL))
+            revisit_penalty = 1.0 / (1.0 + visited_counts[neighbor])
+            weights.append((pheromone_level**alpha) * (heuristic**beta) * revisit_penalty)
+
+        chosen_index = _softmax_choice(rng, np.asarray(weights, dtype=float))
+        current = neighbors[chosen_index]
+        path.append(cast(Any, current))
+        visited_counts[current] += 1
+        if current == GOAL:
+            break
+
+    return _evaluate_path(cast(Any, path))
+
+
+def _evaporate_pheromone(
+    pheromone: dict[tuple[tuple[int, int], tuple[int, int]], float],
+    evaporation_rate: float,
+) -> None:
+    retention = 1.0 - evaporation_rate
+    for edge in list(pheromone):
+        pheromone[edge] = max(1e-6, pheromone[edge] * retention)
+
+
+def _deposit_path(
+    pheromone: dict[tuple[tuple[int, int], tuple[int, int]], float],
+    path: Sequence[tuple[int, int]],
+    amount: float,
+) -> None:
+    if amount <= 0.0:
+        return
+    for start, end in itertools.pairwise(path):
+        pheromone[(start, end)] = pheromone.get((start, end), 1.0) + amount
+        pheromone[(end, start)] = pheromone.get((end, start), 1.0) + amount
+
+
+def _draw_maze(ax: Any, path: Sequence[tuple[int, int]] | None = None, *, title: str = "") -> None:
+    grid = np.asarray(maze, dtype=int)
+    cmap = ListedColormap(["#f8fafc", WALL_COLOR])
+    ax.imshow(grid, cmap=cmap, origin="upper")
+    ax.set_xticks(np.arange(-0.5, grid.shape[1], 1), minor=True)
+    ax.set_yticks(np.arange(-0.5, grid.shape[0], 1), minor=True)
+    ax.grid(which="minor", color="#cbd5e1", linestyle="-", linewidth=0.5)
+    ax.tick_params(which="both", bottom=False, left=False, labelbottom=False, labelleft=False)
+    if path:
+        xs = [point[0] for point in path]
+        ys = [point[1] for point in path]
+        ax.plot(xs, ys, color=PATH_COLOR, linewidth=2.5, marker="o", markersize=3)
+    ax.scatter([START[0]], [START[1]], color=START_COLOR, s=70, label="start", zorder=3)
+    ax.scatter([GOAL[0]], [GOAL[1]], color=GOAL_COLOR, s=70, label="goal", zorder=3)
+    ax.set_xlim(-0.5, grid.shape[1] - 0.5)
+    ax.set_ylim(grid.shape[0] - 0.5, -0.5)
+    ax.set_title(title)
+
+
+def _save_cost_plot(cost_history: Sequence[float], output_path: Path, *, dpi: int) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(7, 4), dpi=dpi)
+    ax.plot(list(cost_history), color=BEST_COLOR, linewidth=2)
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Best cost")
+    ax.set_title("ACO Maze Cost History")
+    ax.grid(True, alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=dpi)
+    plt.close(fig)
+
+
+def _save_path_gif(
+    path_history: Sequence[Sequence[tuple[int, int]]],
+    output_path: Path,
+    *,
+    dpi: int,
+    frame_duration_ms: int,
+    sample_every_n_generations: int,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frame_indices = list(range(0, len(path_history), max(1, sample_every_n_generations)))
+    if not frame_indices or frame_indices[-1] != len(path_history) - 1:
+        frame_indices.append(len(path_history) - 1)
+
+    fig, ax = plt.subplots(figsize=(6, 6), dpi=dpi)
+
+    def update(frame_index: int):
+        ax.clear()
+        _draw_maze(ax, path_history[frame_index], title=f"ACO Iteration {frame_index + 1}")
+        return ()
+
+    animation = FuncAnimation(
+        fig, update, frames=frame_indices, interval=frame_duration_ms, blit=False
+    )
+    writer = PillowWriter(fps=max(1, (round(1000 / frame_duration_ms))))
+    animation.save(output_path, writer=writer)
+    plt.close(fig)
+
+
+def _run_single_experiment(
+    config: LoadedExperimentConfig,
+    *,
+    seed: int,
+    run_index: int,
+) -> dict[str, Any]:
+    aco_config = config.experiment.aco
+    rng = np.random.default_rng(seed)
+    pheromone: dict[tuple[tuple[int, int], tuple[int, int]], float] = {}
+
+    best_result: MazePathResult | None = None
+    best_path_history: list[list[tuple[int, int]]] = []
+    best_cost_history: list[float] = []
+
+    for _iteration in range(aco_config.iterations):
+        ant_results = [
+            _construct_ant_path(
+                rng,
+                pheromone,
+                alpha=aco_config.alpha,
+                beta=aco_config.beta,
+                max_steps=MAX_STEPS,
+            )
+            for _ant in range(aco_config.ant_count)
+        ]
+        iteration_best = min(ant_results, key=lambda result: result.cost)
+        if best_result is None or iteration_best.cost < best_result.cost:
+            best_result = iteration_best
+
+        assert best_result is not None
+        best_path_history.append(list(best_result.path))
+        best_cost_history.append(float(best_result.cost))
+
+        _evaporate_pheromone(pheromone, aco_config.pheromone_evaporation_rate)
+        for result in ant_results:
+            deposit_amount = aco_config.pheromone_constant / max(result.cost, 1.0)
+            _deposit_path(pheromone, result.path, deposit_amount)
+        _deposit_path(
+            pheromone,
+            best_result.path,
+            aco_config.pheromone_constant / max(best_result.cost * 0.5, 1.0),
+        )
+
+    assert best_result is not None
+
+    run_dir = config.output_dir / config.config_name / "aco"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "solver": "aco",
+        "run_index": run_index,
+        "seed": seed,
+        "reached_goal": best_result.reached_goal,
+        "best_cost": float(best_result.cost),
+        "best_path": [list(point) for point in best_result.path],
+        "steps_taken": best_result.steps_taken,
+        "revisits": best_result.revisits,
+        "goal_distance": best_result.goal_distance,
+        "cost_history": best_cost_history,
+        "parameters": config.experiment.aco.model_dump(),
+    }
+
+    if config.experiment.plotting.enabled and config.experiment.plotting.save_cost_plot:
+        _save_cost_plot(
+            best_cost_history,
+            run_dir / "cost_history.png",
+            dpi=config.experiment.plotting.figure_dpi,
+        )
+
+    if config.experiment.gif.enabled and config.experiment.gif.aco_evolution:
+        _save_path_gif(
+            best_path_history,
+            run_dir / "evolution.gif",
+            dpi=config.experiment.plotting.figure_dpi,
+            frame_duration_ms=config.experiment.gif.frame_duration_ms,
+            sample_every_n_generations=config.experiment.gif.sample_every_n_generations,
+        )
+
+    with (run_dir / "summary.json").open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    return summary
+
+
+def run_experiments(config: LoadedExperimentConfig) -> dict[str, Any]:
+    return _run_single_experiment(config, seed=DEFAULT_SEED, run_index=1)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run task03 maze ACO experiments.")
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG_PATH),
+        help="Path to a YAML configuration file.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = load_experiment_config(args.config)
+    summary = run_experiments(config)
+    print(
+        f"ACO best cost={summary['best_cost']:.3f}, reached_goal={summary['reached_goal']}, "
+        f"output={config.output_dir / 'aco'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lab08/task03/src/maze_pso.py
+++ b/lab08/task03/src/maze_pso.py
@@ -1,0 +1,320 @@
+"""Task 03 maze solving with Particle Swarm Optimization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.animation import FuncAnimation, PillowWriter
+from matplotlib.colors import ListedColormap
+
+from task03.data.maze import GOAL, START, is_passable, maze
+
+from .config import DEFAULT_CONFIG_PATH, LoadedExperimentConfig, load_experiment_config
+
+DEFAULT_SEED = 42
+
+ACTIONS: tuple[tuple[int, int], ...] = ((0, -1), (1, 0), (0, 1), (-1, 0))
+ACTION_NAMES: tuple[str, ...] = ("up", "right", "down", "left")
+WALL_COLOR = "#1f2933"
+PATH_COLOR = "#7c3aed"
+START_COLOR = "#16a34a"
+GOAL_COLOR = "#dc2626"
+
+
+@dataclass(frozen=True)
+class MazePathResult:
+    path: list[tuple[int, int]]
+    cost: float
+    reached_goal: bool
+    steps_taken: int
+    revisits: int
+    goal_distance: int
+
+
+def manhattan_distance(a: tuple[int, int], b: tuple[int, int]) -> int:
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def legal_neighbors(cell: tuple[int, int]) -> list[tuple[int, int]]:
+    x, y = cell
+    neighbors: list[tuple[int, int]] = []
+    for dx, dy in ACTIONS:
+        candidate = (x + dx, y + dy)
+        if is_passable(*candidate):
+            neighbors.append(candidate)
+    return neighbors
+
+
+def _decode_particle(particle: np.ndarray) -> list[int]:
+    action_count = len(ACTIONS)
+    expected_dimensions = particle.shape[0]
+    if expected_dimensions % action_count != 0:
+        raise ValueError("particle dimension must be divisible by the number of actions")
+    sequence_length = expected_dimensions // action_count
+    if sequence_length <= 0:
+        raise ValueError("sequence length must be positive")
+    if particle.size != expected_dimensions:
+        raise ValueError(
+            f"particle must have {expected_dimensions} dimensions, got {particle.size}"
+        )
+    reshaped = particle.reshape(sequence_length, action_count)
+    return [int(np.argmax(segment)) for segment in reshaped]
+
+
+def _evaluate_actions(action_indices: Sequence[int], pso_config: Any) -> MazePathResult:
+    current = START
+    path = [current]
+    visited_counts: dict[tuple[int, int], int] = {current: 1}
+
+    for action_index in action_indices:
+        ordered_actions = list(
+            np.argsort(
+                np.asarray([action_index == idx for idx in range(len(ACTIONS))], dtype=float)
+            )
+        )[::-1]
+        candidate = current
+        for idx in ordered_actions:
+            dx, dy = ACTIONS[int(idx)]
+            potential = (current[0] + dx, current[1] + dy)
+            if is_passable(*potential):
+                candidate = potential
+                break
+        current = candidate
+        path.append(cast(Any, current))
+        visited_counts[current] = visited_counts.get(current, 0) + 1
+        if current == GOAL:
+            break
+
+    steps_taken = max(0, len(path) - 1)
+    revisits = len(path) - len(set(path))
+    goal_distance = manhattan_distance(path[-1], GOAL)
+    reached_goal = path[-1] == GOAL
+    if reached_goal:
+        cost = pso_config.step_weight * float(steps_taken) + pso_config.revisit_weight * revisits
+    else:
+        cost = (
+            pso_config.failure_penalty
+            + pso_config.step_weight * float(steps_taken)
+            + pso_config.goal_distance_weight * goal_distance
+            + pso_config.revisit_weight * revisits
+        )
+    return MazePathResult(
+        path=cast(Any, path),
+        cost=cost,
+        reached_goal=reached_goal,
+        steps_taken=steps_taken,
+        revisits=revisits,
+        goal_distance=goal_distance,
+    )
+
+
+def _evaluate_particle(particle: np.ndarray, pso_config: Any) -> MazePathResult:
+    action_indices = _decode_particle(np.asarray(particle, dtype=float))
+    return _evaluate_actions(action_indices, pso_config)
+
+
+def _evaluate_swarm(swarm: np.ndarray, pso_config: Any) -> tuple[np.ndarray, list[MazePathResult]]:
+    results = [_evaluate_particle(particle, pso_config) for particle in swarm]
+    costs = np.asarray([result.cost for result in results], dtype=float)
+    return costs, results
+
+
+# multi-run support removed; single-run uses DEFAULT_SEED
+
+
+def _draw_maze(ax: Any, path: Sequence[tuple[int, int]] | None = None, *, title: str = "") -> None:
+    grid = np.asarray(maze, dtype=int)
+    cmap = ListedColormap(["#f8fafc", WALL_COLOR])
+    ax.imshow(grid, cmap=cmap, origin="upper")
+    ax.set_xticks(np.arange(-0.5, grid.shape[1], 1), minor=True)
+    ax.set_yticks(np.arange(-0.5, grid.shape[0], 1), minor=True)
+    ax.grid(which="minor", color="#cbd5e1", linestyle="-", linewidth=0.5)
+    ax.tick_params(which="both", bottom=False, left=False, labelbottom=False, labelleft=False)
+    if path:
+        xs = [point[0] for point in path]
+        ys = [point[1] for point in path]
+        ax.plot(xs, ys, color=PATH_COLOR, linewidth=2.5, marker="o", markersize=3)
+    ax.scatter([START[0]], [START[1]], color=START_COLOR, s=70, label="start", zorder=3)
+    ax.scatter([GOAL[0]], [GOAL[1]], color=GOAL_COLOR, s=70, label="goal", zorder=3)
+    ax.set_xlim(-0.5, grid.shape[1] - 0.5)
+    ax.set_ylim(grid.shape[0] - 0.5, -0.5)
+    ax.set_title(title)
+
+
+def _save_cost_plot(cost_history: Sequence[float], output_path: Path, *, dpi: int) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(7, 4), dpi=dpi)
+    ax.plot(list(cost_history), color=PATH_COLOR, linewidth=2)
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Best cost")
+    ax.set_title("PSO Maze Cost History")
+    ax.grid(True, alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=dpi)
+    plt.close(fig)
+
+
+def _save_path_gif(
+    path_history: Sequence[Sequence[tuple[int, int]]],
+    output_path: Path,
+    *,
+    dpi: int,
+    frame_duration_ms: int,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(6, 6), dpi=dpi)
+
+    def update(frame_index: int):
+        ax.clear()
+        _draw_maze(ax, path_history[frame_index], title=f"PSO Iteration {frame_index + 1}")
+        return ()
+
+    animation = FuncAnimation(
+        fig, update, frames=range(len(path_history)), interval=frame_duration_ms, blit=False
+    )
+    writer = PillowWriter(fps=max(1, (round(1000 / frame_duration_ms))))
+    animation.save(output_path, writer=writer)
+    plt.close(fig)
+
+
+def _run_pso(
+    config: LoadedExperimentConfig,
+) -> dict[str, Any]:
+    pso_config = config.experiment.pso
+    rng = np.random.default_rng(DEFAULT_SEED)
+
+    dimensions = pso_config.sequence_length * len(ACTIONS)
+    particle_count = pso_config.particle_count
+    iterations = pso_config.iterations
+    lower_bound = pso_config.lower_bound
+    upper_bound = pso_config.upper_bound
+    velocity_clamp = pso_config.velocity_clamp
+
+    swarm = rng.uniform(lower_bound, upper_bound, size=(particle_count, dimensions))
+    velocity = np.zeros_like(swarm)
+
+    costs, results = _evaluate_swarm(swarm, pso_config)
+    personal_best_positions = swarm.copy()
+    personal_best_costs = costs.copy()
+    personal_best_results = list(results)
+
+    global_best_index = int(np.argmin(personal_best_costs))
+    global_best_position = personal_best_positions[global_best_index].copy()
+    global_best_cost = float(personal_best_costs[global_best_index])
+    global_best_result = personal_best_results[global_best_index]
+
+    cost_history: list[float] = []
+    path_history: list[list[tuple[int, int]]] = []
+
+    for _iteration in range(iterations):
+        costs, results = _evaluate_swarm(swarm, pso_config)
+        improved = costs < personal_best_costs
+        if np.any(improved):
+            personal_best_positions[improved] = swarm[improved]
+            personal_best_costs[improved] = costs[improved]
+            for index in np.flatnonzero(improved):
+                personal_best_results[index] = results[index]
+
+        global_best_index = int(np.argmin(personal_best_costs))
+        if float(personal_best_costs[global_best_index]) < global_best_cost:
+            global_best_cost = float(personal_best_costs[global_best_index])
+            global_best_position = personal_best_positions[global_best_index].copy()
+            global_best_result = personal_best_results[global_best_index]
+
+        cost_history.append(global_best_cost)
+        path_history.append(list(global_best_result.path))
+
+        random_1 = rng.random(size=swarm.shape)
+        random_2 = rng.random(size=swarm.shape)
+        velocity = (
+            pso_config.w * velocity
+            + pso_config.c1 * random_1 * (personal_best_positions - swarm)
+            + pso_config.c2 * random_2 * (global_best_position - swarm)
+        )
+        velocity = np.clip(velocity, -velocity_clamp, velocity_clamp)
+        swarm = np.clip(swarm + velocity, lower_bound, upper_bound)
+
+    run_dir = config.output_dir / config.config_name / "pso"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "solver": "pso",
+        "seed": DEFAULT_SEED,
+        "reached_goal": global_best_result.reached_goal,
+        "best_cost": float(global_best_result.cost),
+        "best_path": [list(point) for point in global_best_result.path],
+        "steps_taken": global_best_result.steps_taken,
+        "revisits": global_best_result.revisits,
+        "goal_distance": global_best_result.goal_distance,
+        "cost_history": cost_history,
+        "parameters": config.experiment.pso.model_dump(),
+        "optimizer": {
+            "particle_count": particle_count,
+            "iterations": iterations,
+            "dimensions": dimensions,
+            "lower_bound": lower_bound,
+            "upper_bound": upper_bound,
+            "velocity_clamp": velocity_clamp,
+        },
+    }
+
+    if config.experiment.plotting.enabled and config.experiment.plotting.save_cost_plot:
+        _save_cost_plot(
+            cost_history,
+            run_dir / "cost_history.png",
+            dpi=config.experiment.plotting.figure_dpi,
+        )
+
+    if config.experiment.gif.enabled and config.experiment.gif.pso_evolution:
+        _save_path_gif(
+            path_history,
+            run_dir / "evolution.gif",
+            dpi=config.experiment.plotting.figure_dpi,
+            frame_duration_ms=config.experiment.gif.frame_duration_ms,
+        )
+
+    with (run_dir / "summary.json").open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    return summary
+
+
+def run_experiments(config: LoadedExperimentConfig) -> dict[str, Any]:
+    return _run_pso(config)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run task03 maze PSO experiments.")
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG_PATH),
+        help="Path to a YAML configuration file.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = load_experiment_config(args.config)
+    summary = run_experiments(config)
+    print(
+        f"PSO best cost={summary['best_cost']:.3f}, reached_goal={summary['reached_goal']}, "
+        f"output={config.output_dir / 'pso'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lab08/task03/tests/test_config.py
+++ b/lab08/task03/tests/test_config.py
@@ -1,1 +1,89 @@
 """Tests for task03 YAML configuration loading and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from task03.src.config import DEFAULT_OUTPUT_ROOT, ExperimentConfig, load_experiment_config
+
+
+def test_load_experiment_config_reads_nested_yaml(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "experiment_name: tuned",
+                "output_root: task03/experiments",
+                "aco:",
+                "  ant_count: 11",
+                "  alpha: 0.7",
+                "  beta: 1.1",
+                "  pheromone_evaporation_rate: 0.3",
+                "  pheromone_constant: 500.0",
+                "  iterations: 12",
+                "pso:",
+                "  particle_count: 9",
+                "  iterations: 10",
+                "  sequence_length: 8",
+                "  lower_bound: -3.0",
+                "  upper_bound: 3.0",
+                "  velocity_clamp: 1.5",
+                "  c1: 0.6",
+                "  c2: 0.4",
+                "  w: 0.5",
+                "  step_weight: 1.0",
+                "  revisit_weight: 2.0",
+                "  goal_distance_weight: 5.0",
+                "  failure_penalty: 2000.0",
+                "plotting:",
+                "  enabled: false",
+                "  save_cost_plot: false",
+                "  figure_dpi: 80",
+                "gif:",
+                "  enabled: false",
+                "  aco_evolution: false",
+                "  pso_evolution: false",
+                "  astar_solving: false",
+                "  sample_every_n_generations: 2",
+                "  astar_sample_every_n_steps: 1",
+                "  frame_duration_ms: 120",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_experiment_config(config_path)
+
+    assert loaded.config_name == "tuned"
+    assert loaded.output_root == DEFAULT_OUTPUT_ROOT.resolve()
+    assert loaded.output_dir == DEFAULT_OUTPUT_ROOT.resolve()
+    assert loaded.experiment.aco.ant_count == 11
+    assert loaded.experiment.pso.sequence_length == 8
+    assert loaded.experiment.plotting.enabled is False
+    assert loaded.experiment.gif.enabled is False
+
+
+def test_load_experiment_config_rejects_wrong_output_root(tmp_path: Path) -> None:
+    config_path = tmp_path / "bad_config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "experiment_name: bad",
+                "output_root: /tmp/outside-task03",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="output_root must resolve"):
+        load_experiment_config(config_path)
+
+
+def test_experiment_config_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ExperimentConfig(unexpected_field=True)  # type: ignore

--- a/lab08/task03/tests/test_maze_aco.py
+++ b/lab08/task03/tests/test_maze_aco.py
@@ -1,1 +1,80 @@
 """Tests for task03 Maze ACO implementation."""
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from typing import Any, cast
+
+from task03.data.maze import GOAL, START, is_passable
+from task03.src.config import (
+    ACOConfig,
+    ExperimentConfig,
+    GifConfig,
+    LoadedExperimentConfig,
+    PlotConfig,
+)
+from task03.src.maze_aco import ACTIONS, _evaluate_path, legal_neighbors, run_experiments
+
+
+def _shortest_path() -> list[tuple[int, int]]:
+    queue: deque[tuple[tuple[int, int], list[tuple[int, int]]]] = deque([(START, [START])])
+    visited = {START}
+    while queue:
+        current, path = queue.popleft()
+        if current == GOAL:
+            return path
+        for dx, dy in ACTIONS:
+            candidate = (current[0] + dx, current[1] + dy)
+            if is_passable(*candidate) and candidate not in visited:
+                visited.add(cast(Any, candidate))
+                queue.append((candidate, [*path, candidate]))
+    raise AssertionError("maze has no path from start to goal")
+
+
+def test_legal_neighbors_from_start() -> None:
+    assert legal_neighbors(START) == [(2, 1)]
+
+
+def test_evaluate_path_uses_path_length_and_revisits() -> None:
+    path = _shortest_path()
+
+    result = _evaluate_path(path)
+
+    assert result.reached_goal is True
+    assert result.steps_taken == len(path) - 1
+    assert result.revisits == 0
+    assert result.goal_distance == 0
+    assert result.cost == float(len(path) - 1)
+
+
+def test_run_experiments_writes_summary(tmp_path: Path) -> None:
+    experiment = ExperimentConfig(
+        aco=ACOConfig(
+            ant_count=8,
+            alpha=0.6,
+            beta=1.0,
+            pheromone_evaporation_rate=0.35,
+            pheromone_constant=250.0,
+            iterations=10,
+        ),
+        plotting=PlotConfig(enabled=False, save_cost_plot=False, figure_dpi=80),
+        gif=GifConfig(enabled=False, aco_evolution=False, pso_evolution=False, astar_solving=False),
+    )
+    config = LoadedExperimentConfig(
+        config_path=tmp_path / "config.yaml",
+        config_name="aco-test",
+        project_root=tmp_path,
+        task_root=tmp_path,
+        output_root=tmp_path,
+        output_dir=tmp_path,
+        experiment=experiment,
+    )
+
+    summary = run_experiments(config)
+
+    summary_path = tmp_path / "aco-test" / "aco" / "summary.json"
+    assert summary_path.exists()
+    assert summary["solver"] == "aco"
+    assert summary["seed"] == 42
+    assert summary["best_path"][0] == list(START)

--- a/lab08/task03/tests/test_maze_pso.py
+++ b/lab08/task03/tests/test_maze_pso.py
@@ -1,1 +1,110 @@
 """Tests for task03 Maze PSO implementation."""
+
+from __future__ import annotations
+
+import itertools
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+
+from task03.data.maze import GOAL, START, is_passable
+from task03.src.config import (
+    ExperimentConfig,
+    GifConfig,
+    LoadedExperimentConfig,
+    PlotConfig,
+    PSOConfig,
+)
+from task03.src.maze_pso import ACTIONS, _decode_particle, _evaluate_actions, run_experiments
+
+
+def _shortest_path() -> list[tuple[int, int]]:
+    queue: deque[tuple[tuple[int, int], list[tuple[int, int]]]] = deque([(START, [START])])
+    visited = {START}
+    while queue:
+        current, path = queue.popleft()
+        if current == GOAL:
+            return path
+        for dx, dy in ACTIONS:
+            candidate = (current[0] + dx, current[1] + dy)
+            if is_passable(*candidate) and candidate not in visited:
+                visited.add(cast(Any, candidate))
+                queue.append((candidate, [*path, candidate]))
+    raise AssertionError("maze has no path from start to goal")
+
+
+def _path_to_actions(path: list[tuple[int, int]]) -> list[int]:
+    action_lookup = {action: index for index, action in enumerate(ACTIONS)}
+    action_indices: list[int] = []
+    for start, end in itertools.pairwise(path):
+        delta = (end[0] - start[0], end[1] - start[1])
+        action_indices.append(action_lookup[delta])
+    return action_indices
+
+
+def test_decode_particle_chooses_segment_argmax() -> None:
+    particle = np.asarray([0.1, 2.0, 0.3, -1.0, 5.0, 1.0, 0.0, 4.0], dtype=float)
+
+    assert _decode_particle(particle) == [1, 0]
+
+
+def test_evaluate_actions_on_shortest_path() -> None:
+    path = _shortest_path()
+    action_indices = _path_to_actions(path)
+    pso_config = SimpleNamespace(
+        step_weight=1.0,
+        revisit_weight=0.0,
+        goal_distance_weight=4.0,
+        failure_penalty=1000.0,
+    )
+
+    result = _evaluate_actions(action_indices, pso_config)
+
+    assert result.reached_goal is True
+    assert result.steps_taken == len(path) - 1
+    assert result.revisits == 0
+    assert result.goal_distance == 0
+    assert result.cost == float(len(path) - 1)
+
+
+def test_run_experiments_with_tuned_config_reaches_goal(tmp_path: Path) -> None:
+    experiment = ExperimentConfig(
+        pso=PSOConfig(
+            particle_count=90,
+            iterations=160,
+            sequence_length=30,
+            lower_bound=-4.0,
+            upper_bound=4.0,
+            velocity_clamp=2.0,
+            c1=0.5,
+            c2=0.3,
+            w=0.5,
+            step_weight=1.0,
+            revisit_weight=2.0,
+            goal_distance_weight=5.0,
+            failure_penalty=2000.0,
+        ),
+        plotting=PlotConfig(enabled=False, save_cost_plot=False, figure_dpi=80),
+        gif=GifConfig(enabled=False, aco_evolution=False, pso_evolution=False, astar_solving=False),
+    )
+    config = LoadedExperimentConfig(
+        config_path=tmp_path / "config.yaml",
+        config_name="pso-test",
+        project_root=tmp_path,
+        task_root=tmp_path,
+        output_root=tmp_path,
+        output_dir=tmp_path,
+        experiment=experiment,
+    )
+
+    summary = run_experiments(config)
+
+    summary_path = tmp_path / "pso-test" / "pso" / "summary.json"
+    assert summary_path.exists()
+    assert summary["solver"] == "pso"
+    assert summary["seed"] == 42
+    assert summary["reached_goal"] is True
+    assert summary["best_path"][-1] == list(GOAL)


### PR DESCRIPTION
### ci: adding pyright check for task02 and task03 84cd9db6e7070c44b9dcda5eb6884cb1da946e14
### ci: pyright checks 265495e59f5bba72124689cb22685829359c34bf
Added task02 and task03 (and later task03/tests) to pyright checks.

### feat: logic, data and configs 4638b5fc48ec5dfeb8dffeb4e3bfae54b1b93270
Implementation of PSO and ACO logic, config files and config.py to run the files and bringing maze from previous labs task03 to check the work and compare the results.

### test: config test and aco, pso tests b33f3e74c89cbb02b0add66b7e445a81752eb4b8
Added tests to verify the algorithms working and config.py logic working correctly

---

closes #72 